### PR TITLE
Add configurable CSV path and validation unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 gcc -std=c11 -Wall -Wextra -O2 -o maint main.c
 ```
 
+### Test
+
+```bash
+gcc -std=c11 -Wall -Wextra -O2 -DUNIT_TEST -I. -o tests/test_validation tests/test_validation.c main.c
+./tests/test_validation
+```
+
 ### Run
 
 ```bash

--- a/main.c
+++ b/main.c
@@ -1,14 +1,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdlib.h>
 
-#define CSV_FILE "maintenance.csv"
+#include "maintenance.h"
 
-#define MAX_RECORDS 1000
-#define MAX_NAME 64
-#define MAX_ID 32
-#define MAX_DATE 16
-#define MAX_DETAILS 256
+static char csv_file_path[CSV_PATH_MAX] = CSV_FILE_DEFAULT;
 
 char machineName[MAX_RECORDS][MAX_NAME];
 char machineID[MAX_RECORDS][MAX_ID];
@@ -16,16 +13,35 @@ char maintenanceDate[MAX_RECORDS][MAX_DATE];
 char maintenanceDetails[MAX_RECORDS][MAX_DETAILS];
 int record_count = 0;
 
+const char *maintenance_get_csv_path(void)
+{
+    return csv_file_path;
+}
+
+int maintenance_set_csv_path(const char *path)
+{
+    if (!path || path[0] == '\0')
+    {
+        return -1;
+    }
+
+    size_t len = strlen(path);
+    if (len >= CSV_PATH_MAX)
+    {
+        return -1;
+    }
+
+    if (snprintf(csv_file_path, sizeof(csv_file_path), "%s", path) < 0)
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+#ifndef UNIT_TEST
 void display_menu(void);
-int ensure_csv_exists(void);
-int load_records(void);
-int save_all_records(void);
-void display_records(void);
-void add_record(void);
-void search_records(void);
-void update_record(void);
-void delete_record(void);
-int safe_input(char *buffer, int size, const char *prompt);
+int read_menu_choice(void);
 
 int main(void)
 {
@@ -44,20 +60,7 @@ int main(void)
     do
     {
         display_menu();
-        printf("Enter your choice: ");
-        if (scanf("%d", &choice) != 1)
-        {
-            int c;
-            while ((c = getchar()) != '\n' && c != EOF)
-            {
-            }
-            choice = 0;
-        }
-
-        int ch;
-        while ((ch = getchar()) != '\n' && ch != EOF)
-        {
-        }
+        choice = read_menu_choice();
 
         switch (choice)
         {
@@ -101,7 +104,9 @@ int main(void)
 
     return 0;
 }
+#endif /* UNIT_TEST */
 
+#ifndef UNIT_TEST
 void display_menu(void)
 {
     printf("\nMachine Maintenance Manager\n");
@@ -112,17 +117,19 @@ void display_menu(void)
     printf("5. Delete record\n");
     printf("6. Exit\n");
 }
+#endif
 
 int ensure_csv_exists(void)
 {
-    FILE *f = fopen(CSV_FILE, "r");
+    const char *path = maintenance_get_csv_path();
+    FILE *f = fopen(path, "r");
     if (f)
     {
         fclose(f);
         return 0;
     }
 
-    f = fopen(CSV_FILE, "w");
+    f = fopen(path, "w");
     if (!f)
     {
         perror("Create CSV");
@@ -139,7 +146,8 @@ int ensure_csv_exists(void)
 
 int load_records(void)
 {
-    FILE *file = fopen(CSV_FILE, "r");
+    const char *path = maintenance_get_csv_path();
+    FILE *file = fopen(path, "r");
     if (!file)
     {
         perror("Open CSV");
@@ -161,17 +169,10 @@ int load_records(void)
         if (matched != 4)
             break;
 
-        strncpy(machineName[record_count], n, MAX_NAME - 1);
-        machineName[record_count][MAX_NAME - 1] = '\0';
-
-        strncpy(machineID[record_count], id, MAX_ID - 1);
-        machineID[record_count][MAX_ID - 1] = '\0';
-
-        strncpy(maintenanceDate[record_count], d, MAX_DATE - 1);
-        maintenanceDate[record_count][MAX_DATE - 1] = '\0';
-
-        strncpy(maintenanceDetails[record_count], det, MAX_DETAILS - 1);
-        maintenanceDetails[record_count][MAX_DETAILS - 1] = '\0';
+        snprintf(machineName[record_count], MAX_NAME, "%s", n);
+        snprintf(machineID[record_count], MAX_ID, "%s", id);
+        snprintf(maintenanceDate[record_count], MAX_DATE, "%s", d);
+        snprintf(maintenanceDetails[record_count], MAX_DETAILS, "%s", det);
 
         record_count++;
     }
@@ -186,7 +187,8 @@ int load_records(void)
 
 int save_all_records(void)
 {
-    FILE *file = fopen(CSV_FILE, "w");
+    const char *path = maintenance_get_csv_path();
+    FILE *file = fopen(path, "w");
     if (!file)
     {
         perror("Open CSV for write");
@@ -235,13 +237,17 @@ void add_record(void)
 
     char n[MAX_NAME], id[MAX_ID], d[MAX_DATE], det[MAX_DETAILS];
 
-    if (safe_input(n, sizeof(n), "Enter machine name: ") != 0)
+    if (prompt_with_validation(n, MAX_NAME, "Enter machine name: ",
+                               is_valid_machine_name,
+                               "Machine name must be printable text without commas or quotes.") != 0)
     {
         printf("Error reading machine name.\n");
         return;
     }
 
-    if (safe_input(id, sizeof(id), "Enter machine ID: ") != 0)
+    if (prompt_with_validation(id, MAX_ID, "Enter machine ID: ",
+                               is_valid_machine_id,
+                               "Machine ID must use letters, numbers, dashes, underscores or dots only.") != 0)
     {
         printf("Error reading machine ID.\n");
         return;
@@ -256,29 +262,26 @@ void add_record(void)
         }
     }
 
-    if (safe_input(d, sizeof(d), "Enter maintenance date (YYYY-MM-DD): ") != 0)
+    if (prompt_with_validation(d, MAX_DATE, "Enter maintenance date (YYYY-MM-DD): ",
+                               is_valid_date,
+                               "Date must follow YYYY-MM-DD with a real calendar day.") != 0)
     {
         printf("Error reading maintenance date.\n");
         return;
     }
 
-    if (safe_input(det, sizeof(det), "Enter maintenance details: ") != 0)
+    if (prompt_with_validation(det, MAX_DETAILS, "Enter maintenance details: ",
+                               is_valid_details,
+                               "Details must not be empty, contain commas or quotes.") != 0)
     {
         printf("Error reading maintenance details.\n");
         return;
     }
 
-    strncpy(machineName[record_count], n, MAX_NAME - 1);
-    machineName[record_count][MAX_NAME - 1] = '\0';
-
-    strncpy(machineID[record_count], id, MAX_ID - 1);
-    machineID[record_count][MAX_ID - 1] = '\0';
-
-    strncpy(maintenanceDate[record_count], d, MAX_DATE - 1);
-    maintenanceDate[record_count][MAX_DATE - 1] = '\0';
-
-    strncpy(maintenanceDetails[record_count], det, MAX_DETAILS - 1);
-    maintenanceDetails[record_count][MAX_DETAILS - 1] = '\0';
+    snprintf(machineName[record_count], MAX_NAME, "%s", n);
+    snprintf(machineID[record_count], MAX_ID, "%s", id);
+    snprintf(maintenanceDate[record_count], MAX_DATE, "%s", d);
+    snprintf(maintenanceDetails[record_count], MAX_DETAILS, "%s", det);
 
     record_count++;
     printf("Record added.\n");
@@ -286,10 +289,12 @@ void add_record(void)
 
 void search_records(void)
 {
-    char q[64];
+    char q[MAX_NAME];
     int found = 0;
 
-    if (safe_input(q, sizeof(q), "Enter machine name or ID to search: ") != 0)
+    if (prompt_with_validation(q, MAX_NAME, "Enter machine name or ID to search: ",
+                               is_non_empty,
+                               "Search text cannot be empty.") != 0)
     {
         printf("Error reading search query.\n");
         return;
@@ -317,9 +322,10 @@ void search_records(void)
 void update_record(void)
 {
     char id[MAX_ID];
-    char buf[MAX_DETAILS];
 
-    if (safe_input(id, sizeof(id), "Enter machine ID to update: ") != 0)
+    if (prompt_with_validation(id, MAX_ID, "Enter machine ID to update: ",
+                               is_valid_machine_id,
+                               "Machine ID must use letters, numbers, dashes, underscores or dots only.") != 0)
     {
         printf("Error reading machine ID.\n");
         return;
@@ -330,43 +336,22 @@ void update_record(void)
         if (strcmp(machineID[i], id) == 0)
         {
             printf("Current Name: %s\n", machineName[i]);
-            printf("New name (leave blank to keep): ");
-            buf[0] = '\0';
-            if (fgets(buf, sizeof(buf), stdin) != NULL)
-            {
-                if (buf[0] != '\n' && buf[0] != '\0')
-                {
-                    buf[strcspn(buf, "\r\n")] = '\0';
-                    strncpy(machineName[i], buf, MAX_NAME - 1);
-                    machineName[i][MAX_NAME - 1] = '\0';
-                }
-            }
+            prompt_optional_update("New name (leave blank to keep): ",
+                                   machineName[i], MAX_NAME,
+                                   is_valid_machine_name,
+                                   "Machine name must be printable text without commas or quotes.");
 
             printf("Current Date: %s\n", maintenanceDate[i]);
-            printf("New date YYYY-MM-DD (leave blank to keep): ");
-            buf[0] = '\0';
-            if (fgets(buf, sizeof(buf), stdin) != NULL)
-            {
-                if (buf[0] != '\n' && buf[0] != '\0')
-                {
-                    buf[strcspn(buf, "\r\n")] = '\0';
-                    strncpy(maintenanceDate[i], buf, MAX_DATE - 1);
-                    maintenanceDate[i][MAX_DATE - 1] = '\0';
-                }
-            }
+            prompt_optional_update("New date YYYY-MM-DD (leave blank to keep): ",
+                                   maintenanceDate[i], MAX_DATE,
+                                   is_valid_date,
+                                   "Date must follow YYYY-MM-DD with a real calendar day.");
 
             printf("Current Details: %s\n", maintenanceDetails[i]);
-            printf("New details (leave blank to keep): ");
-            buf[0] = '\0';
-            if (fgets(buf, sizeof(buf), stdin) != NULL)
-            {
-                if (buf[0] != '\n' && buf[0] != '\0')
-                {
-                    buf[strcspn(buf, "\r\n")] = '\0';
-                    strncpy(maintenanceDetails[i], buf, MAX_DETAILS - 1);
-                    maintenanceDetails[i][MAX_DETAILS - 1] = '\0';
-                }
-            }
+            prompt_optional_update("New details (leave blank to keep): ",
+                                   maintenanceDetails[i], MAX_DETAILS,
+                                   is_valid_details,
+                                   "Details must not be empty, contain commas or quotes.");
 
             printf("Record updated.\n");
             return;
@@ -379,7 +364,9 @@ void delete_record(void)
 {
     char id[MAX_ID];
     
-    if (safe_input(id, sizeof(id), "Enter machine ID to delete: ") != 0)
+    if (prompt_with_validation(id, MAX_ID, "Enter machine ID to delete: ",
+                               is_valid_machine_id,
+                               "Machine ID must use letters, numbers, dashes, underscores or dots only.") != 0)
     {
         printf("Error reading machine ID.\n");
         return;
@@ -392,10 +379,10 @@ void delete_record(void)
             for (int j = i; j < record_count - 1; ++j)
             {
 
-                strncpy(machineName[j], machineName[j + 1], MAX_NAME);
-                strncpy(machineID[j], machineID[j + 1], MAX_ID);
-                strncpy(maintenanceDate[j], maintenanceDate[j + 1], MAX_DATE);
-                strncpy(maintenanceDetails[j], maintenanceDetails[j + 1], MAX_DETAILS);
+                snprintf(machineName[j], MAX_NAME, "%s", machineName[j + 1]);
+                snprintf(machineID[j], MAX_ID, "%s", machineID[j + 1]);
+                snprintf(maintenanceDate[j], MAX_DATE, "%s", maintenanceDate[j + 1]);
+                snprintf(maintenanceDetails[j], MAX_DETAILS, "%s", maintenanceDetails[j + 1]);
             }
             record_count--;
             printf("Record deleted.\n");
@@ -407,13 +394,292 @@ void delete_record(void)
 
 int safe_input(char *buffer, int size, const char *prompt)
 {
+    if (size <= 0)
+    {
+        return -1;
+    }
+
     printf("%s", prompt);
     if (fgets(buffer, size, stdin) == NULL)
     {
         return -1;
     }
-    
-    // Remove trailing newline
-    buffer[strcspn(buffer, "\r\n")] = '\0';
+
+    sanitize_input(buffer);
     return 0;
+}
+
+int prompt_with_validation(char *buffer, int size, const char *prompt,
+                           int (*validator)(const char *), const char *error_message)
+{
+    if (size <= 0)
+    {
+        return -1;
+    }
+
+    while (1)
+    {
+        if (safe_input(buffer, size, prompt) != 0)
+        {
+            return -1;
+        }
+
+        if (!validator || validator(buffer))
+        {
+            return 0;
+        }
+
+        if (error_message)
+        {
+            printf("%s\n", error_message);
+        }
+    }
+}
+
+#ifndef UNIT_TEST
+int read_menu_choice(void)
+{
+    char buffer[16];
+
+    while (1)
+    {
+        if (safe_input(buffer, sizeof(buffer), "Enter your choice: ") != 0)
+        {
+            printf("Input error detected. Exiting menu.\n");
+            return 6;
+        }
+
+        if (buffer[0] == '\0')
+        {
+            printf("Invalid choice. Please enter a number between 1 and 6.\n");
+            continue;
+        }
+
+        char *endptr = NULL;
+        long value = strtol(buffer, &endptr, 10);
+        if (endptr != NULL && *endptr == '\0' && value >= 1 && value <= 6)
+        {
+            return (int)value;
+        }
+
+        printf("Invalid choice. Please enter a number between 1 and 6.\n");
+    }
+}
+#endif
+
+void trim_whitespace(char *str)
+{
+    if (!str)
+    {
+        return;
+    }
+
+    char *start = str;
+    while (*start && isspace((unsigned char)*start))
+    {
+        start++;
+    }
+
+    if (start != str)
+    {
+        memmove(str, start, strlen(start) + 1);
+    }
+
+    size_t len = strlen(str);
+    while (len > 0 && isspace((unsigned char)str[len - 1]))
+    {
+        str[len - 1] = '\0';
+        len--;
+    }
+}
+
+void flush_line(void)
+{
+    int ch;
+    while ((ch = getchar()) != '\n' && ch != EOF)
+    {
+    }
+}
+
+void sanitize_input(char *buffer)
+{
+    if (!buffer)
+    {
+        return;
+    }
+
+    size_t len = strcspn(buffer, "\r\n");
+    if (buffer[len] != '\0')
+    {
+        buffer[len] = '\0';
+    }
+    else
+    {
+        flush_line();
+    }
+
+    trim_whitespace(buffer);
+}
+
+int is_non_empty(const char *str)
+{
+    return (str != NULL && str[0] != '\0');
+}
+
+int contains_disallowed_csv_chars(const char *str)
+{
+    if (!str)
+    {
+        return 0;
+    }
+
+    for (const char *p = str; *p; ++p)
+    {
+        if (*p == ',' || *p == '"')
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int is_valid_machine_name(const char *str)
+{
+    if (!is_non_empty(str) || contains_disallowed_csv_chars(str))
+    {
+        return 0;
+    }
+
+    for (const char *p = str; *p; ++p)
+    {
+        if (!isprint((unsigned char)*p))
+        {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int is_valid_machine_id(const char *str)
+{
+    if (!is_non_empty(str) || contains_disallowed_csv_chars(str))
+    {
+        return 0;
+    }
+
+    for (const char *p = str; *p; ++p)
+    {
+        if (!(isalnum((unsigned char)*p) || *p == '-' || *p == '_' || *p == '.'))
+        {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int is_valid_date(const char *str)
+{
+    if (!str)
+    {
+        return 0;
+    }
+
+    if (strlen(str) != 10)
+    {
+        return 0;
+    }
+
+    for (int i = 0; i < 10; ++i)
+    {
+        if (i == 4 || i == 7)
+        {
+            if (str[i] != '-')
+            {
+                return 0;
+            }
+        }
+        else if (!isdigit((unsigned char)str[i]))
+        {
+            return 0;
+        }
+    }
+
+    int year = (str[0] - '0') * 1000 + (str[1] - '0') * 100 + (str[2] - '0') * 10 + (str[3] - '0');
+    int month = (str[5] - '0') * 10 + (str[6] - '0');
+    int day = (str[8] - '0') * 10 + (str[9] - '0');
+
+    if (month < 1 || month > 12)
+    {
+        return 0;
+    }
+
+    int days_in_month[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    int is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+    if (is_leap)
+    {
+        days_in_month[1] = 29;
+    }
+
+    if (day < 1 || day > days_in_month[month - 1])
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
+int is_valid_details(const char *str)
+{
+    if (!is_non_empty(str) || contains_disallowed_csv_chars(str))
+    {
+        return 0;
+    }
+
+    for (const char *p = str; *p; ++p)
+    {
+        if (!isprint((unsigned char)*p))
+        {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+void prompt_optional_update(const char *prompt, char *dest, int dest_size,
+                            int (*validator)(const char *), const char *error_message)
+{
+    if (!dest || dest_size <= 0)
+    {
+        return;
+    }
+
+    char buffer[MAX_DETAILS];
+
+    while (1)
+    {
+        printf("%s", prompt);
+        if (fgets(buffer, sizeof(buffer), stdin) == NULL)
+        {
+            printf("Input error. Field unchanged.\n");
+            return;
+        }
+
+        sanitize_input(buffer);
+
+        if (buffer[0] == '\0')
+        {
+            return;
+        }
+
+        if (!validator || validator(buffer))
+        {
+            snprintf(dest, dest_size, "%s", buffer);
+            return;
+        }
+
+        if (error_message)
+        {
+            printf("%s\n", error_message);
+        }
+    }
 }

--- a/main.c
+++ b/main.c
@@ -653,7 +653,7 @@ void prompt_optional_update(const char *prompt, char *dest, int dest_size,
         return;
     }
   
-    char buffer[MAX_DETAILS];
+    char buffer[dest_size];
 
     while (1)
     {

--- a/main.c
+++ b/main.c
@@ -31,8 +31,10 @@ int maintenance_set_csv_path(const char *path)
         return -1;
     }
 
-    if (snprintf(csv_file_path, sizeof(csv_file_path), "%s", path) < 0)
+    int written = snprintf(csv_file_path, sizeof(csv_file_path), "%s", path);
+    if (written >= sizeof(csv_file_path))
     {
+        // Truncation occurred
         return -1;
     }
 

--- a/maintenance.h
+++ b/maintenance.h
@@ -1,0 +1,46 @@
+#ifndef MAINTENANCE_H
+#define MAINTENANCE_H
+
+#include <stddef.h>
+
+#ifndef CSV_FILE_DEFAULT
+#define CSV_FILE_DEFAULT "maintenance.csv"
+#endif
+
+#ifndef CSV_PATH_MAX
+#define CSV_PATH_MAX 512
+#endif
+
+#define MAX_RECORDS 1000
+#define MAX_NAME 64
+#define MAX_ID 32
+#define MAX_DATE 16
+#define MAX_DETAILS 256
+
+int ensure_csv_exists(void);
+int load_records(void);
+int save_all_records(void);
+void display_records(void);
+void add_record(void);
+void search_records(void);
+void update_record(void);
+void delete_record(void);
+int safe_input(char *buffer, int size, const char *prompt);
+int prompt_with_validation(char *buffer, int size, const char *prompt,
+                           int (*validator)(const char *), const char *error_message);
+void trim_whitespace(char *str);
+void sanitize_input(char *buffer);
+int is_non_empty(const char *str);
+int is_valid_machine_name(const char *str);
+int is_valid_machine_id(const char *str);
+int is_valid_date(const char *str);
+int is_valid_details(const char *str);
+int contains_disallowed_csv_chars(const char *str);
+void prompt_optional_update(const char *prompt, char *dest, int dest_size,
+                            int (*validator)(const char *), const char *error_message);
+int maintenance_set_csv_path(const char *path);
+const char *maintenance_get_csv_path(void);
+
+extern int record_count;
+
+#endif /* MAINTENANCE_H */

--- a/tests/test_validation.c
+++ b/tests/test_validation.c
@@ -1,0 +1,154 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "maintenance.h"
+
+static int tests_run = 0;
+static int tests_failed = 0;
+
+#define EXPECT_TRUE(expr)                                                                    \
+    do                                                                                       \
+    {                                                                                        \
+        ++tests_run;                                                                         \
+        if (!(expr))                                                                         \
+        {                                                                                    \
+            ++tests_failed;                                                                  \
+            fprintf(stderr, "EXPECT_TRUE failed: %s (line %d)\n", #expr, __LINE__);          \
+        }                                                                                    \
+    } while (0)
+
+#define EXPECT_STREQ(expected, actual)                                                       \
+    do                                                                                       \
+    {                                                                                        \
+        ++tests_run;                                                                         \
+        if (strcmp((expected), (actual)) != 0)                                               \
+        {                                                                                    \
+            ++tests_failed;                                                                  \
+            fprintf(stderr,                                                                  \
+                    "EXPECT_STREQ failed: expected '%s' but got '%s' (line %d)\n",           \
+                    (expected), (actual), __LINE__);                                         \
+        }                                                                                    \
+    } while (0)
+
+static void test_trim_whitespace(void)
+{
+    char str1[] = "  Hello World  ";
+    trim_whitespace(str1);
+    EXPECT_STREQ("Hello World", str1);
+
+    char str2[] = "   \t  ";
+    trim_whitespace(str2);
+    EXPECT_STREQ("", str2);
+
+    char str3[] = "\tSpacing\n";
+    trim_whitespace(str3);
+    EXPECT_STREQ("Spacing", str3);
+}
+
+static void test_sanitize_input(void)
+{
+    char str1[] = "  Value with spaces \r\n";
+    sanitize_input(str1);
+    EXPECT_STREQ("Value with spaces", str1);
+
+    char str2[] = "\tAnother Value\n";
+    sanitize_input(str2);
+    EXPECT_STREQ("Another Value", str2);
+}
+
+static void test_is_non_empty(void)
+{
+    EXPECT_TRUE(is_non_empty("Hello"));
+    EXPECT_TRUE(!is_non_empty(""));
+    EXPECT_TRUE(!is_non_empty(NULL));
+}
+
+static void test_contains_disallowed_csv_chars(void)
+{
+    EXPECT_TRUE(contains_disallowed_csv_chars("bad,comma"));
+    EXPECT_TRUE(contains_disallowed_csv_chars("bad\"quote"));
+    EXPECT_TRUE(!contains_disallowed_csv_chars("good value"));
+}
+
+static void test_is_valid_machine_name(void)
+{
+    EXPECT_TRUE(is_valid_machine_name("Lathe 100"));
+    EXPECT_TRUE(!is_valid_machine_name(""));
+    EXPECT_TRUE(!is_valid_machine_name("Bad,Name"));
+
+    char non_printable[] = "Valid\x01";
+    EXPECT_TRUE(!is_valid_machine_name(non_printable));
+}
+
+static void test_is_valid_machine_id(void)
+{
+    EXPECT_TRUE(is_valid_machine_id("ID-123_45.6"));
+    EXPECT_TRUE(!is_valid_machine_id("with space"));
+    EXPECT_TRUE(!is_valid_machine_id("comma,here"));
+    EXPECT_TRUE(!is_valid_machine_id("invalid#char"));
+}
+
+static void test_is_valid_date(void)
+{
+    EXPECT_TRUE(is_valid_date("2024-02-29"));
+    EXPECT_TRUE(!is_valid_date("2024-02-30"));
+    EXPECT_TRUE(!is_valid_date("2024-13-01"));
+    EXPECT_TRUE(!is_valid_date("2024/02/01"));
+    EXPECT_TRUE(!is_valid_date("20240201"));
+}
+
+static void test_is_valid_details(void)
+{
+    EXPECT_TRUE(is_valid_details("Replaced filter"));
+    EXPECT_TRUE(!is_valid_details(""));
+    EXPECT_TRUE(!is_valid_details("Contains,comma"));
+
+    char invalid[] = "Bad\nDetail";
+    EXPECT_TRUE(!is_valid_details(invalid));
+}
+
+static void test_csv_path_management(void)
+{
+    char original[CSV_PATH_MAX];
+    snprintf(original, sizeof(original), "%s", maintenance_get_csv_path());
+
+    EXPECT_TRUE(maintenance_set_csv_path("tests/tmp-maintenance.csv") == 0);
+    EXPECT_STREQ("tests/tmp-maintenance.csv", maintenance_get_csv_path());
+
+    EXPECT_TRUE(maintenance_set_csv_path(NULL) == -1);
+    EXPECT_STREQ("tests/tmp-maintenance.csv", maintenance_get_csv_path());
+
+    EXPECT_TRUE(maintenance_set_csv_path("") == -1);
+    EXPECT_STREQ("tests/tmp-maintenance.csv", maintenance_get_csv_path());
+
+    char long_path[CSV_PATH_MAX + 5];
+    memset(long_path, 'a', sizeof(long_path));
+    long_path[sizeof(long_path) - 1] = '\0';
+    EXPECT_TRUE(maintenance_set_csv_path(long_path) == -1);
+    EXPECT_STREQ("tests/tmp-maintenance.csv", maintenance_get_csv_path());
+
+    EXPECT_TRUE(maintenance_set_csv_path(original) == 0);
+    EXPECT_STREQ(original, maintenance_get_csv_path());
+}
+
+int main(void)
+{
+    test_trim_whitespace();
+    test_sanitize_input();
+    test_is_non_empty();
+    test_contains_disallowed_csv_chars();
+    test_is_valid_machine_name();
+    test_is_valid_machine_id();
+    test_is_valid_date();
+    test_is_valid_details();
+    test_csv_path_management();
+
+    if (tests_failed != 0)
+    {
+        fprintf(stderr, "\n%d of %d expectations failed.\n", tests_failed, tests_run);
+        return 1;
+    }
+
+    printf("All %d expectations passed.\n", tests_run);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extract shared limits and helpers into a new `maintenance.h` header and expose functions for overriding the CSV file path
- update the main program to respect the configurable CSV path and gate the CLI entrypoint when building unit tests
- add comprehensive unit tests for sanitation and validator helpers and document how to build/run them in the README

## Testing
- gcc -std=c11 -Wall -Wextra -O2 -o maint main.c
- gcc -std=c11 -Wall -Wextra -O2 -DUNIT_TEST -I. -o tests/test_validation tests/test_validation.c main.c
- ./tests/test_validation


------
https://chatgpt.com/codex/tasks/task_e_68cc14ee833883208c35f5e7b9a8f403