### PR TITLE
Flush stdout after prompts

### DIFF
--- a/main.c
+++ b/main.c
@@ -402,6 +402,7 @@ int safe_input(char *buffer, int size, const char *prompt)
     }
 
     printf("%s", prompt);
+    fflush(stdout);
     if (fgets(buffer, size, stdin) == NULL)
     {
         return -1;


### PR DESCRIPTION
## Summary
- flush stdout after printing input prompts so they appear immediately when stdout is buffered

## Testing
- gcc -std=c11 -O2 -Wall -Wextra -o MachineManager main.c
- gcc -std=c11 -O2 -Wall -Wextra -DUNIT_TEST -I. tests/test_validation.c main.c -o tests/test_validation
- ./tests/test_validation

------
https://chatgpt.com/codex/tasks/task_e_68cc2394af1c83209838eea735847947