### PR TITLE
Add interactive CSV bootstrap setup

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,12 +6,61 @@
 #include "maintenance.h"
 
 static char csv_file_path[CSV_PATH_MAX] = CSV_FILE_DEFAULT;
+static const char *SAMPLE_CSV_FILE = "maintenance-example.csv";
+static const char CSV_HEADER[] = "MachineName,MachineID,MaintenanceDate,MaintenanceDetails\n";
 
 char machineName[MAX_RECORDS][MAX_NAME];
 char machineID[MAX_RECORDS][MAX_ID];
 char maintenanceDate[MAX_RECORDS][MAX_DATE];
 char maintenanceDetails[MAX_RECORDS][MAX_DETAILS];
 int record_count = 0;
+
+static void print_cancel_message(void)
+{
+    printf("\nOperation cancelled. Returning to Machine Maintenance Manager.\n");
+}
+
+static void flush_line(void);
+static int prompt_copy_from_sample(void);
+static int write_blank_csv(const char *path);
+static int copy_example_csv(const char *path);
+
+static int handle_prompt_result(int status, const char *error_message)
+{
+    if (status == INPUT_CANCELLED)
+    {
+        print_cancel_message();
+        return 1;
+    }
+
+    if (status == INPUT_ERROR)
+    {
+        if (error_message)
+        {
+            printf("%s\n", error_message);
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+int reload_records_with_warning(void)
+{
+    if (load_records() != 0)
+    {
+        const char *path = maintenance_get_csv_path();
+        if (!path || path[0] == '\0')
+        {
+            path = "(unknown)";
+        }
+
+        printf("Warning: Failed to reload records from '%s'. Data may be stale.\n", path);
+        return -1;
+    }
+
+    return 0;
+}
 
 const char *maintenance_get_csv_path(void)
 {
@@ -32,7 +81,7 @@ int maintenance_set_csv_path(const char *path)
     }
 
     int written = snprintf(csv_file_path, sizeof(csv_file_path), "%s", path);
-    if (written >= sizeof(csv_file_path))
+    if (written < 0 || (size_t)written >= sizeof(csv_file_path))
     {
         // Truncation occurred
         return -1;
@@ -73,8 +122,7 @@ int main(void)
             add_record();
             if (save_all_records() == 0)
             {
-                // Reload to reflect changes
-                load_records();
+                reload_records_with_warning();
             }
             break;
         case 3:
@@ -84,16 +132,14 @@ int main(void)
             update_record();
             if (save_all_records() == 0)
             {
-                // Reload to reflect changes
-                load_records();  
+                reload_records_with_warning();
             }
             break;
         case 5:
             delete_record();
             if (save_all_records() == 0)
             {
-                // Reload to reflect changes
-                load_records();
+                reload_records_with_warning();
             }
             break;
         case 6:
@@ -131,19 +177,160 @@ int ensure_csv_exists(void)
         return 0;
     }
 
-    f = fopen(path, "w");
+    printf("No maintenance data file found at '%s'.\n", path);
+
+    int choice = prompt_copy_from_sample();
+    if (choice < 0)
+    {
+        handle_prompt_result(choice, "Error reading setup choice.");
+        return -1;
+    }
+
+    if (choice == 1)
+    {
+        if (copy_example_csv(path) == 0)
+        {
+            printf("Created '%s' using sample data from '%s'.\n", path, SAMPLE_CSV_FILE);
+            return 0;
+        }
+
+        printf("Failed to copy sample data. Creating an empty maintenance file instead.\n");
+    }
+
+    if (write_blank_csv(path) != 0)
+    {
+        return -1;
+    }
+
+    printf("Created empty maintenance file at '%s'.\n", path);
+    return 0;
+}
+
+static int prompt_copy_from_sample(void)
+{
+    char prompt[128];
+    snprintf(prompt, sizeof(prompt), "Copy sample data from %s? (y/n): ", SAMPLE_CSV_FILE);
+
+    while (1)
+    {
+        char response[8];
+        int status = safe_input(response, sizeof(response), prompt);
+
+        if (status == INPUT_CANCELLED)
+        {
+            return INPUT_CANCELLED;
+        }
+
+        if (status == INPUT_TOO_LONG)
+        {
+            continue;
+        }
+
+        if (status == INPUT_ERROR)
+        {
+            return INPUT_ERROR;
+        }
+
+        if (status != INPUT_OK)
+        {
+            continue;
+        }
+
+        if (response[0] == '\0')
+        {
+            printf("Please enter 'y' or 'n'.\n");
+            continue;
+        }
+
+        char c = (char)tolower((unsigned char)response[0]);
+        if (c == 'y')
+        {
+            return 1;
+        }
+        if (c == 'n')
+        {
+            return 0;
+        }
+
+        printf("Please enter 'y' or 'n'.\n");
+    }
+}
+
+static int write_blank_csv(const char *path)
+{
+    FILE *f = fopen(path, "w");
     if (!f)
     {
         perror("Create CSV");
         return -1;
     }
-    fprintf(f, "MachineName,MachineID,MaintenanceDate,MaintenanceDetails\n");
+
+    if (fputs(CSV_HEADER, f) == EOF)
+    {
+        perror("Write CSV header");
+        fclose(f);
+        return -1;
+    }
+
     if (fclose(f) != 0)
     {
         perror("Close CSV");
         return -1;
     }
+
     return 0;
+}
+
+static int copy_example_csv(const char *path)
+{
+    FILE *src = fopen(SAMPLE_CSV_FILE, "r");
+    if (!src)
+    {
+        perror("Open example CSV");
+        return -1;
+    }
+
+    FILE *dst = fopen(path, "w");
+    if (!dst)
+    {
+        perror("Create CSV from example");
+        fclose(src);
+        return -1;
+    }
+
+    char buffer[1024];
+    size_t bytes_read;
+    int error = 0;
+
+    while ((bytes_read = fread(buffer, 1, sizeof(buffer), src)) > 0)
+    {
+        if (fwrite(buffer, 1, bytes_read, dst) != bytes_read)
+        {
+            perror("Write CSV");
+            error = 1;
+            break;
+        }
+    }
+
+    if (!error && ferror(src))
+    {
+        perror("Read example CSV");
+        error = 1;
+    }
+
+    if (fclose(dst) != 0)
+    {
+        perror("Close CSV after copy");
+        error = 1;
+    }
+
+    if (fclose(src) != 0)
+    {
+        perror("Close example CSV");
+        error = 1;
+    }
+
+    return error ? -1 : 0;
 }
 
 int load_records(void)
@@ -164,12 +351,19 @@ int load_records(void)
     } /* ไม่มีข้อมูล */
 
     record_count = 0;
-    while (record_count < MAX_RECORDS)
+    int overflow_detected = 0;
+    while (1)
     {
         char n[MAX_NAME], id[MAX_ID], d[MAX_DATE], det[MAX_DETAILS];
         int matched = fscanf(file, " %63[^,],%31[^,],%15[^,],%255[^\n]\n", n, id, d, det);
         if (matched != 4)
             break;
+
+        if (is_record_storage_full())
+        {
+            overflow_detected = 1;
+            continue;
+        }
 
         snprintf(machineName[record_count], MAX_NAME, "%s", n);
         snprintf(machineID[record_count], MAX_ID, "%s", id);
@@ -177,6 +371,12 @@ int load_records(void)
         snprintf(maintenanceDetails[record_count], MAX_DETAILS, "%s", det);
 
         record_count++;
+    }
+
+    if (overflow_detected)
+    {
+        printf("Warning: Maximum record capacity of %d reached. Extra records were ignored to prevent overflow.\n",
+               MAX_RECORDS);
     }
 
     if (fclose(file) != 0)
@@ -197,7 +397,7 @@ int save_all_records(void)
         return -1;
     }
 
-    fprintf(file, "MachineName,MachineID,MaintenanceDate,MaintenanceDetails\n");
+    fputs(CSV_HEADER, file);
     for (int i = 0; i < record_count; ++i)
     {
         fprintf(file, "%s,%s,%s,%s\n",
@@ -231,7 +431,7 @@ void display_records(void)
 
 void add_record(void)
 {
-    if (record_count >= MAX_RECORDS)
+    if (is_record_storage_full())
     {
         printf("Storage full.\n");
         return;
@@ -239,19 +439,19 @@ void add_record(void)
 
     char n[MAX_NAME], id[MAX_ID], d[MAX_DATE], det[MAX_DETAILS];
 
-    if (prompt_with_validation(n, MAX_NAME, "Enter machine name: ",
-                               is_valid_machine_name,
-                               "Machine name must be printable text without commas or quotes.") != 0)
+    int status = prompt_with_validation(n, MAX_NAME, "Enter machine name: ",
+                                        is_valid_machine_name,
+                                        "Machine name must be printable text without commas or quotes.");
+    if (handle_prompt_result(status, "Error reading machine name."))
     {
-        printf("Error reading machine name.\n");
         return;
     }
 
-    if (prompt_with_validation(id, MAX_ID, "Enter machine ID: ",
-                               is_valid_machine_id,
-                               "Machine ID must use letters, numbers, dashes, underscores or dots only.") != 0)
+    status = prompt_with_validation(id, MAX_ID, "Enter machine ID: ",
+                                    is_valid_machine_id,
+                                    "Machine ID must use letters, numbers, dashes, underscores or dots only.");
+    if (handle_prompt_result(status, "Error reading machine ID."))
     {
-        printf("Error reading machine ID.\n");
         return;
     }
 
@@ -264,19 +464,19 @@ void add_record(void)
         }
     }
 
-    if (prompt_with_validation(d, MAX_DATE, "Enter maintenance date (YYYY-MM-DD): ",
-                               is_valid_date,
-                               "Date must follow YYYY-MM-DD with a real calendar day.") != 0)
+    status = prompt_with_validation(d, MAX_DATE, "Enter maintenance date (YYYY-MM-DD): ",
+                                    is_valid_date,
+                                    "Date must follow YYYY-MM-DD with a real calendar day.");
+    if (handle_prompt_result(status, "Error reading maintenance date."))
     {
-        printf("Error reading maintenance date.\n");
         return;
     }
 
-    if (prompt_with_validation(det, MAX_DETAILS, "Enter maintenance details: ",
-                               is_valid_details,
-                               "Details must not be empty, contain commas or quotes.") != 0)
+    status = prompt_with_validation(det, MAX_DETAILS, "Enter maintenance details: ",
+                                    is_valid_details,
+                                    "Details must not be empty, contain commas or quotes.");
+    if (handle_prompt_result(status, "Error reading maintenance details."))
     {
-        printf("Error reading maintenance details.\n");
         return;
     }
 
@@ -294,11 +494,11 @@ void search_records(void)
     char q[MAX_NAME];
     int found = 0;
 
-    if (prompt_with_validation(q, MAX_NAME, "Enter machine name or ID to search: ",
-                               is_non_empty,
-                               "Search text cannot be empty.") != 0)
+    int status = prompt_with_validation(q, MAX_NAME, "Enter machine name or ID to search: ",
+                                        is_non_empty,
+                                        "Search text cannot be empty.");
+    if (handle_prompt_result(status, "Error reading search query."))
     {
-        printf("Error reading search query.\n");
         return;
     }
 
@@ -325,11 +525,11 @@ void update_record(void)
 {
     char id[MAX_ID];
 
-    if (prompt_with_validation(id, MAX_ID, "Enter machine ID to update: ",
-                               is_valid_machine_id,
-                               "Machine ID must use letters, numbers, dashes, underscores or dots only.") != 0)
+    int status = prompt_with_validation(id, MAX_ID, "Enter machine ID to update: ",
+                                        is_valid_machine_id,
+                                        "Machine ID must use letters, numbers, dashes, underscores or dots only.");
+    if (handle_prompt_result(status, "Error reading machine ID."))
     {
-        printf("Error reading machine ID.\n");
         return;
     }
 
@@ -337,23 +537,47 @@ void update_record(void)
     {
         if (strcmp(machineID[i], id) == 0)
         {
+            char new_name[MAX_NAME];
+            char new_date[MAX_DATE];
+            char new_details[MAX_DETAILS];
+
+            snprintf(new_name, sizeof(new_name), "%s", machineName[i]);
+            snprintf(new_date, sizeof(new_date), "%s", maintenanceDate[i]);
+            snprintf(new_details, sizeof(new_details), "%s", maintenanceDetails[i]);
+
             printf("Current Name: %s\n", machineName[i]);
-            prompt_optional_update("New name (leave blank to keep): ",
-                                   machineName[i], MAX_NAME,
-                                   is_valid_machine_name,
-                                   "Machine name must be printable text without commas or quotes.");
+            status = prompt_optional_update("New name (leave blank to keep): ",
+                                             new_name, MAX_NAME,
+                                             is_valid_machine_name,
+                                             "Machine name must be printable text without commas or quotes.");
+            if (status != INPUT_OK && handle_prompt_result(status, "Error updating machine name."))
+            {
+                return;
+            }
 
             printf("Current Date: %s\n", maintenanceDate[i]);
-            prompt_optional_update("New date YYYY-MM-DD (leave blank to keep): ",
-                                   maintenanceDate[i], MAX_DATE,
-                                   is_valid_date,
-                                   "Date must follow YYYY-MM-DD with a real calendar day.");
+            status = prompt_optional_update("New date YYYY-MM-DD (leave blank to keep): ",
+                                             new_date, MAX_DATE,
+                                             is_valid_date,
+                                             "Date must follow YYYY-MM-DD with a real calendar day.");
+            if (status != INPUT_OK && handle_prompt_result(status, "Error updating maintenance date."))
+            {
+                return;
+            }
 
             printf("Current Details: %s\n", maintenanceDetails[i]);
-            prompt_optional_update("New details (leave blank to keep): ",
-                                   maintenanceDetails[i], MAX_DETAILS,
-                                   is_valid_details,
-                                   "Details must not be empty, contain commas or quotes.");
+            status = prompt_optional_update("New details (leave blank to keep): ",
+                                             new_details, MAX_DETAILS,
+                                             is_valid_details,
+                                             "Details must not be empty, contain commas or quotes.");
+            if (status != INPUT_OK && handle_prompt_result(status, "Error updating maintenance details."))
+            {
+                return;
+            }
+
+            snprintf(machineName[i], MAX_NAME, "%s", new_name);
+            snprintf(maintenanceDate[i], MAX_DATE, "%s", new_date);
+            snprintf(maintenanceDetails[i], MAX_DETAILS, "%s", new_details);
 
             printf("Record updated.\n");
             return;
@@ -366,11 +590,11 @@ void delete_record(void)
 {
     char id[MAX_ID];
     
-    if (prompt_with_validation(id, MAX_ID, "Enter machine ID to delete: ",
-                               is_valid_machine_id,
-                               "Machine ID must use letters, numbers, dashes, underscores or dots only.") != 0)
+    int status = prompt_with_validation(id, MAX_ID, "Enter machine ID to delete: ",
+                                        is_valid_machine_id,
+                                        "Machine ID must use letters, numbers, dashes, underscores or dots only.");
+    if (handle_prompt_result(status, "Error reading machine ID."))
     {
-        printf("Error reading machine ID.\n");
         return;
     }
 
@@ -380,11 +604,10 @@ void delete_record(void)
         {
             for (int j = i; j < record_count - 1; ++j)
             {
-
-                snprintf(machineName[j], MAX_NAME, "%s", machineName[j + 1]);
-                snprintf(machineID[j], MAX_ID, "%s", machineID[j + 1]);
-                snprintf(maintenanceDate[j], MAX_DATE, "%s", maintenanceDate[j + 1]);
-                snprintf(maintenanceDetails[j], MAX_DETAILS, "%s", maintenanceDetails[j + 1]);
+                memmove(machineName[j], machineName[j + 1], sizeof(machineName[j]));
+                memmove(machineID[j], machineID[j + 1], sizeof(machineID[j]));
+                memmove(maintenanceDate[j], maintenanceDate[j + 1], sizeof(maintenanceDate[j]));
+                memmove(maintenanceDetails[j], maintenanceDetails[j + 1], sizeof(maintenanceDetails[j]));
             }
             record_count--;
             printf("Record deleted.\n");
@@ -398,17 +621,38 @@ int safe_input(char *buffer, int size, const char *prompt)
 {
     if (size <= 0)
     {
-        return -1;
+        return INPUT_ERROR;
     }
 
     printf("%s", prompt);
+    fflush(stdout);
     if (fgets(buffer, size, stdin) == NULL)
     {
-        return -1;
+        return INPUT_ERROR;
+    }
+
+    int truncated = (strchr(buffer, '\n') == NULL);
+
+    if (contains_cancel_signal(buffer))
+    {
+        if (truncated)
+        {
+            flush_line();
+        }
+        buffer[0] = '\0';
+        return INPUT_CANCELLED;
     }
 
     sanitize_input(buffer);
-    return 0;
+
+    if (truncated)
+    {
+        printf("Input too long. Maximum length is %d characters.\n", size - 1);
+        buffer[0] = '\0';
+        return INPUT_TOO_LONG;
+    }
+
+    return INPUT_OK;
 }
 
 int prompt_with_validation(char *buffer, int size, const char *prompt,
@@ -416,19 +660,30 @@ int prompt_with_validation(char *buffer, int size, const char *prompt,
 {
     if (size <= 0)
     {
-        return -1;
+        return INPUT_ERROR;
     }
 
     while (1)
     {
-        if (safe_input(buffer, size, prompt) != 0)
+        int status = safe_input(buffer, size, prompt);
+        if (status == INPUT_CANCELLED)
         {
-            return -1;
+            return INPUT_CANCELLED;
+        }
+
+        if (status == INPUT_ERROR)
+        {
+            return INPUT_ERROR;
+        }
+
+        if (status == INPUT_TOO_LONG)
+        {
+            continue;
         }
 
         if (!validator || validator(buffer))
         {
-            return 0;
+            return INPUT_OK;
         }
 
         if (error_message)
@@ -445,10 +700,22 @@ int read_menu_choice(void)
 
     while (1)
     {
-        if (safe_input(buffer, sizeof(buffer), "Enter your choice: ") != 0)
+        int status = safe_input(buffer, sizeof(buffer), "Enter your choice: ");
+        if (status == INPUT_CANCELLED)
+        {
+            print_cancel_message();
+            continue;
+        }
+
+        if (status == INPUT_ERROR)
         {
             printf("Input error detected. Exiting menu.\n");
             return 6;
+        }
+
+        if (status == INPUT_TOO_LONG)
+        {
+            continue;
         }
 
         if (buffer[0] == '\0')
@@ -495,7 +762,7 @@ void trim_whitespace(char *str)
     }
 }
 
-void flush_line(void)
+static void flush_line(void)
 {
     int ch;
     while ((ch = getchar()) != '\n' && ch != EOF)
@@ -542,6 +809,24 @@ int contains_disallowed_csv_chars(const char *str)
             return 1;
         }
     }
+    return 0;
+}
+
+int contains_cancel_signal(const char *str)
+{
+    if (!str)
+    {
+        return 0;
+    }
+
+    for (const unsigned char *p = (const unsigned char *)str; *p != '\0'; ++p)
+    {
+        if (*p == 0x18)
+        {
+            return 1;
+        }
+    }
+
     return 0;
 }
 
@@ -647,36 +932,49 @@ int is_valid_details(const char *str)
     return 1;
 }
 
-void prompt_optional_update(const char *prompt, char *dest, int dest_size,
-                            int (*validator)(const char *), const char *error_message)
+int is_record_storage_full(void)
+{
+    return (record_count < 0) || (record_count >= MAX_RECORDS);
+}
+
+int prompt_optional_update(const char *prompt, char *dest, int dest_size,
+                           int (*validator)(const char *), const char *error_message)
 {
     if (!dest || dest_size <= 0)
     {
-        return;
+        return INPUT_ERROR;
     }
-  
+
     char buffer[dest_size];
 
     while (1)
     {
-        printf("%s", prompt);
-        if (fgets(buffer, sizeof(buffer), stdin) == NULL)
+        int status = safe_input(buffer, sizeof(buffer), prompt);
+        if (status == INPUT_CANCELLED)
         {
-            printf("Input error. Field unchanged.\n");
-            return;
+            return INPUT_CANCELLED;
         }
 
-        sanitize_input(buffer);
+        if (status == INPUT_ERROR)
+        {
+            printf("Input error. Field unchanged.\n");
+            return INPUT_ERROR;
+        }
+
+        if (status == INPUT_TOO_LONG)
+        {
+            continue;
+        }
 
         if (buffer[0] == '\0')
         {
-            return;
+            return INPUT_OK;
         }
 
         if (!validator || validator(buffer))
         {
             snprintf(dest, dest_size, "%s", buffer);
-            return;
+            return INPUT_OK;
         }
 
         if (error_message)

--- a/maintenance.h
+++ b/maintenance.h
@@ -17,9 +17,15 @@
 #define MAX_DATE 16
 #define MAX_DETAILS 256
 
+#define INPUT_OK 0
+#define INPUT_ERROR -1
+#define INPUT_CANCELLED -2
+#define INPUT_TOO_LONG -3
+
 int ensure_csv_exists(void);
 int load_records(void);
 int save_all_records(void);
+int reload_records_with_warning(void);
 void display_records(void);
 void add_record(void);
 void search_records(void);
@@ -36,10 +42,12 @@ int is_valid_machine_id(const char *str);
 int is_valid_date(const char *str);
 int is_valid_details(const char *str);
 int contains_disallowed_csv_chars(const char *str);
-void prompt_optional_update(const char *prompt, char *dest, int dest_size,
-                            int (*validator)(const char *), const char *error_message);
+int prompt_optional_update(const char *prompt, char *dest, int dest_size,
+                           int (*validator)(const char *), const char *error_message);
 int maintenance_set_csv_path(const char *path);
 const char *maintenance_get_csv_path(void);
+int contains_cancel_signal(const char *str);
+int is_record_storage_full(void);
 
 extern int record_count;
 

--- a/tests/test_validation.c
+++ b/tests/test_validation.c
@@ -1,5 +1,8 @@
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "maintenance.h"
 
@@ -29,6 +32,66 @@ static int tests_failed = 0;
                     (expected), (actual), __LINE__);                                         \
         }                                                                                    \
     } while (0)
+
+static int redirect_stdin_from_string(const char *text, int *saved_fd, FILE **temp_file)
+{
+    if (!text || !saved_fd || !temp_file)
+    {
+        return -1;
+    }
+
+    *saved_fd = dup(fileno(stdin));
+    if (*saved_fd < 0)
+    {
+        return -1;
+    }
+
+    *temp_file = tmpfile();
+    if (!*temp_file)
+    {
+        close(*saved_fd);
+        *saved_fd = -1;
+        return -1;
+    }
+
+    if (fputs(text, *temp_file) == EOF)
+    {
+        fclose(*temp_file);
+        *temp_file = NULL;
+        close(*saved_fd);
+        *saved_fd = -1;
+        return -1;
+    }
+
+    rewind(*temp_file);
+
+    if (dup2(fileno(*temp_file), fileno(stdin)) < 0)
+    {
+        fclose(*temp_file);
+        *temp_file = NULL;
+        close(*saved_fd);
+        *saved_fd = -1;
+        return -1;
+    }
+
+    return 0;
+}
+
+static void restore_stdin(int saved_fd, FILE *temp_file)
+{
+    if (saved_fd >= 0)
+    {
+        dup2(saved_fd, fileno(stdin));
+        close(saved_fd);
+    }
+
+    if (temp_file)
+    {
+        fclose(temp_file);
+    }
+
+    clearerr(stdin);
+}
 
 static void test_trim_whitespace(void)
 {
@@ -107,6 +170,32 @@ static void test_is_valid_details(void)
     EXPECT_TRUE(!is_valid_details(invalid));
 }
 
+static void test_contains_cancel_signal(void)
+{
+    char with_cancel[] = {'A', 0x18, 'B', '\0'};
+    char no_cancel[] = "Normal text";
+
+    EXPECT_TRUE(contains_cancel_signal(with_cancel));
+    EXPECT_TRUE(!contains_cancel_signal(no_cancel));
+    EXPECT_TRUE(!contains_cancel_signal(NULL));
+}
+
+static void test_is_record_storage_full(void)
+{
+    int original = record_count;
+
+    record_count = 0;
+    EXPECT_TRUE(!is_record_storage_full());
+
+    record_count = MAX_RECORDS;
+    EXPECT_TRUE(is_record_storage_full());
+
+    record_count = -1;
+    EXPECT_TRUE(is_record_storage_full());
+
+    record_count = original;
+}
+
 static void test_csv_path_management(void)
 {
     char original[CSV_PATH_MAX];
@@ -131,6 +220,167 @@ static void test_csv_path_management(void)
     EXPECT_STREQ(original, maintenance_get_csv_path());
 }
 
+static void test_reload_records_with_warning(void)
+{
+    char original[CSV_PATH_MAX];
+    snprintf(original, sizeof(original), "%s", maintenance_get_csv_path());
+
+    EXPECT_TRUE(maintenance_set_csv_path("tests/nonexistent.csv") == 0);
+
+    FILE *capture = tmpfile();
+    EXPECT_TRUE(capture != NULL);
+
+    int saved_stdout_fd = dup(fileno(stdout));
+    EXPECT_TRUE(saved_stdout_fd >= 0);
+
+    int capture_fd = fileno(capture);
+    EXPECT_TRUE(capture_fd >= 0);
+
+    fflush(stdout);
+    EXPECT_TRUE(dup2(capture_fd, fileno(stdout)) >= 0);
+
+    int rc = reload_records_with_warning();
+
+    fflush(stdout);
+    EXPECT_TRUE(dup2(saved_stdout_fd, fileno(stdout)) >= 0);
+    close(saved_stdout_fd);
+
+    rewind(capture);
+    char buffer[256];
+    size_t read = fread(buffer, 1, sizeof(buffer) - 1, capture);
+    buffer[read] = '\0';
+    fclose(capture);
+
+    EXPECT_TRUE(rc != 0);
+    EXPECT_TRUE(strstr(buffer, "Warning: Failed to reload records") != NULL);
+
+    EXPECT_TRUE(maintenance_set_csv_path(original) == 0);
+    EXPECT_STREQ(original, maintenance_get_csv_path());
+}
+
+static void test_ensure_csv_exists_creates_blank_when_declined(void)
+{
+    char original[CSV_PATH_MAX];
+    snprintf(original, sizeof(original), "%s", maintenance_get_csv_path());
+
+    const char *path = "tests/tmp-blank.csv";
+    unlink(path);
+    EXPECT_TRUE(maintenance_set_csv_path(path) == 0);
+
+    int saved_fd = -1;
+    FILE *temp = NULL;
+    EXPECT_TRUE(redirect_stdin_from_string("n\n", &saved_fd, &temp) == 0);
+
+    EXPECT_TRUE(ensure_csv_exists() == 0);
+
+    restore_stdin(saved_fd, temp);
+
+    FILE *created = fopen(path, "r");
+    EXPECT_TRUE(created != NULL);
+    if (created)
+    {
+        char buffer[256];
+        size_t read = fread(buffer, 1, sizeof(buffer) - 1, created);
+        buffer[read] = '\0';
+        fclose(created);
+
+        EXPECT_STREQ("MachineName,MachineID,MaintenanceDate,MaintenanceDetails\n", buffer);
+    }
+
+    unlink(path);
+    EXPECT_TRUE(maintenance_set_csv_path(original) == 0);
+}
+
+static void test_ensure_csv_exists_copies_sample_when_requested(void)
+{
+    char original[CSV_PATH_MAX];
+    snprintf(original, sizeof(original), "%s", maintenance_get_csv_path());
+
+    const char *path = "tests/tmp-copy.csv";
+    unlink(path);
+    EXPECT_TRUE(maintenance_set_csv_path(path) == 0);
+
+    int saved_fd = -1;
+    FILE *temp = NULL;
+    EXPECT_TRUE(redirect_stdin_from_string("y\n", &saved_fd, &temp) == 0);
+
+    EXPECT_TRUE(ensure_csv_exists() == 0);
+
+    restore_stdin(saved_fd, temp);
+
+    FILE *created = fopen(path, "r");
+    EXPECT_TRUE(created != NULL);
+
+    FILE *example = fopen("maintenance-example.csv", "r");
+    EXPECT_TRUE(example != NULL);
+
+    if (created && example)
+    {
+        char created_buffer[8192];
+        char example_buffer[8192];
+
+        size_t created_read = fread(created_buffer, 1, sizeof(created_buffer), created);
+        size_t example_read = fread(example_buffer, 1, sizeof(example_buffer), example);
+
+        fclose(created);
+        fclose(example);
+
+        EXPECT_TRUE(created_read == example_read);
+        if (created_read == example_read)
+        {
+            EXPECT_TRUE(memcmp(created_buffer, example_buffer, created_read) == 0);
+        }
+    }
+    else
+    {
+        if (created)
+        {
+            fclose(created);
+        }
+        if (example)
+        {
+            fclose(example);
+        }
+    }
+
+    unlink(path);
+    EXPECT_TRUE(maintenance_set_csv_path(original) == 0);
+}
+
+static void test_ensure_csv_exists_preserves_existing_file(void)
+{
+    char original[CSV_PATH_MAX];
+    snprintf(original, sizeof(original), "%s", maintenance_get_csv_path());
+
+    const char *path = "tests/tmp-existing.csv";
+    unlink(path);
+
+    FILE *existing = fopen(path, "w");
+    EXPECT_TRUE(existing != NULL);
+    if (existing)
+    {
+        fputs("existing data\n", existing);
+        fclose(existing);
+    }
+
+    EXPECT_TRUE(maintenance_set_csv_path(path) == 0);
+    EXPECT_TRUE(ensure_csv_exists() == 0);
+
+    FILE *check = fopen(path, "r");
+    EXPECT_TRUE(check != NULL);
+    if (check)
+    {
+        char buffer[64];
+        size_t read = fread(buffer, 1, sizeof(buffer) - 1, check);
+        buffer[read] = '\0';
+        fclose(check);
+        EXPECT_STREQ("existing data\n", buffer);
+    }
+
+    unlink(path);
+    EXPECT_TRUE(maintenance_set_csv_path(original) == 0);
+}
+
 int main(void)
 {
     test_trim_whitespace();
@@ -141,7 +391,13 @@ int main(void)
     test_is_valid_machine_id();
     test_is_valid_date();
     test_is_valid_details();
+    test_contains_cancel_signal();
+    test_is_record_storage_full();
     test_csv_path_management();
+    test_reload_records_with_warning();
+    test_ensure_csv_exists_creates_blank_when_declined();
+    test_ensure_csv_exists_copies_sample_when_requested();
+    test_ensure_csv_exists_preserves_existing_file();
 
     if (tests_failed != 0)
     {


### PR DESCRIPTION
## Summary
- prompt operators to copy the bundled maintenance-example.csv or create a blank file when maintenance.csv is missing, sharing a header constant across writers
- add helper routines to copy the sample data or initialise an empty CSV so setup failures report clearly
- extend the validation suite with stdin redirection helpers to verify the new bootstrap flows for copying, blank creation, and preserving existing data

## Testing
- gcc -std=c11 -Wall -Wextra -o MachineManager main.c
- gcc -std=c11 -Wall -Wextra -DUNIT_TEST -I. main.c tests/test_validation.c -o tests/test_validation
- ./tests/test_validation


------
https://chatgpt.com/codex/tasks/task_e_68cc1ec15bc48320ba76b2e5d88ec118