### PR TITLE
Add security policy and cross-platform CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,25 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Ensure GCC is available (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          gcc --version
+
+      - name: Install GCC (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install gcc
+          GCC_PREFIX="$(brew --prefix gcc)"
+          GCC_VERSION="$(brew list --versions gcc | awk '{print $2}')"
+          GCC_MAJOR="${GCC_VERSION%%.*}"
+          mkdir -p "$HOME/.local/bin"
+          ln -sf "$GCC_PREFIX/bin/gcc-${GCC_MAJOR}" "$HOME/.local/bin/gcc"
+          ln -sf "$GCC_PREFIX/bin/g++-${GCC_MAJOR}" "$HOME/.local/bin/g++"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          gcc --version
+
       - name: Set up MSYS2 (Windows)
         if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
@@ -42,6 +61,11 @@ jobs:
           msystem: MINGW64
           install: >-
             mingw-w64-x86_64-gcc
+
+      - name: Verify GCC (Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: gcc --version
 
       - name: Build application
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,110 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: maint-linux
+            packaged_name: maint-linux
+          - os: macos-latest
+            artifact_name: maint-macos
+            packaged_name: maint-macos
+          - os: windows-latest
+            artifact_name: maint-windows
+            packaged_name: maint-windows.exe
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2 (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: MINGW64
+          install: >-
+            mingw-w64-x86_64-gcc
+
+      - name: Build application
+        if: runner.os != 'Windows'
+        run: gcc -std=c11 -Wall -Wextra -O2 -o maint main.c
+
+      - name: Build application (Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: gcc -std=c11 -Wall -Wextra -O2 -o maint.exe main.c
+
+      - name: Run unit tests
+        if: runner.os != 'Windows'
+        run: |
+          gcc -std=c11 -Wall -Wextra -O2 -DUNIT_TEST -I. -o tests/test_validation tests/test_validation.c main.c
+          ./tests/test_validation
+
+      - name: Run unit tests (Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          gcc -std=c11 -Wall -Wextra -O2 -DUNIT_TEST -I. -o tests/test_validation.exe tests/test_validation.c main.c
+          ./tests/test_validation.exe
+
+      - name: Package artifact
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p dist
+          cp maint dist/${{ matrix.packaged_name }}
+          (cd dist && zip -r ../${{ matrix.artifact_name }}.zip ${{ matrix.packaged_name }})
+
+      - name: Package artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          $destination = Join-Path dist '${{ matrix.packaged_name }}'
+          Copy-Item maint.exe $destination -Force
+          Compress-Archive -Path '${{ matrix.packaged_name }}' -DestinationPath '${{ matrix.artifact_name }}.zip' -Force -WorkingDirectory dist
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}.zip
+
+  release:
+    needs: build-and-test
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/**/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: List packaged assets
+        run: ls -R artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           $destination = Join-Path dist '${{ matrix.packaged_name }}'
           Copy-Item maint.exe $destination -Force
-          Compress-Archive -Path '${{ matrix.packaged_name }}' -DestinationPath '${{ matrix.artifact_name }}.zip' -Force -WorkingDirectory dist
+          Push-Location dist
+          Compress-Archive -Path '${{ matrix.packaged_name }}' -DestinationPath "../${{ matrix.artifact_name }}.zip" -Force
+          Pop-Location
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| main    | ✅ |
+
+Bug fixes and security updates are actively applied to the `main` branch. Older tags may not receive updates.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately so we can address them quickly:
+
+1. Use GitHub's **Security → Report a vulnerability** workflow to open a private security advisory for this repository.
+2. If the advisory workflow is unavailable, email the maintainers at `security@project.local` with as much detail as possible, including:
+   - A description of the issue and potential impact
+   - Steps to reproduce or proof-of-concept code
+   - Any suggested mitigations
+
+Please **do not** create public GitHub issues for security reports.
+
+## Preferred Communication Language
+
+We can respond to reports in either English or Thai. We aim to acknowledge new reports within 3 business days and provide status updates at least once per week until the issue is resolved.
+
+## Disclosure Policy
+
+Once a fix or mitigation is available, we will coordinate a disclosure date with you before making the report public. If we cannot reach you, we may proceed with disclosure after releasing a patch.


### PR DESCRIPTION
## Summary
- document how to report vulnerabilities in a new `SECURITY.md`
- build and test `main.c` on Linux, macOS, and Windows using GitHub Actions
- package artifacts per platform and publish them automatically when tags are pushed

## Testing
- gcc -std=c11 -Wall -Wextra -O2 -DUNIT_TEST -I. -o tests/test_validation tests/test_validation.c main.c && ./tests/test_validation


------
https://chatgpt.com/codex/tasks/task_e_68cc324e5db883208275df1d6bf6ed0c