### PR TITLE
Handle EOF without newline in safe_input

### DIFF
--- a/main.c
+++ b/main.c
@@ -2880,7 +2880,14 @@ int safe_input(char *buffer, int size, const char *prompt)
         return INPUT_ERROR;
     }
 
-    int truncated = (strchr(buffer, '\n') == NULL);
+    char *newline = strchr(buffer, '\n');
+    int truncated = (newline == NULL && !feof(stdin));
+
+    if (newline)
+    {
+        *newline = '\0';
+    }
+
     if (contains_cancel_signal(buffer))
     {
         if (truncated)
@@ -2901,14 +2908,15 @@ int safe_input(char *buffer, int size, const char *prompt)
         return INPUT_BACK;
     }
 
-    sanitize_input(buffer);
-
     if (truncated)
     {
+        flush_line();
         printf("Input too long. Maximum length is %d characters.\n", size - 1);
         buffer[0] = '\0';
         return INPUT_TOO_LONG;
     }
+
+    sanitize_input(buffer);
 
     return INPUT_OK;
 }
@@ -3071,10 +3079,6 @@ void sanitize_input(char *buffer)
     if (buffer[len] != '\0')
     {
         buffer[len] = '\0';
-    }
-    else
-    {
-        flush_line();
     }
 
     trim_whitespace(buffer);

--- a/main.c
+++ b/main.c
@@ -2881,11 +2881,22 @@ int safe_input(char *buffer, int size, const char *prompt)
     }
 
     char *newline = strchr(buffer, '\n');
-    int truncated = (newline == NULL && !feof(stdin));
+    int newline_missing = (newline == NULL);
 
     if (newline)
     {
         *newline = '\0';
+    }
+
+    int stream_error = ferror(stdin);
+    int eof_reached = feof(stdin);
+    int truncated = (newline_missing && !eof_reached && !stream_error);
+
+    if (stream_error)
+    {
+        clearerr(stdin);
+        buffer[0] = '\0';
+        return INPUT_ERROR;
     }
 
     if (contains_cancel_signal(buffer))

--- a/tests/test_validation.c
+++ b/tests/test_validation.c
@@ -138,6 +138,25 @@ static void test_safe_input_eof_without_newline(void)
     EXPECT_STREQ("EOF without newline", buffer);
 }
 
+static void test_safe_input_overflow_flushes(void)
+{
+    int saved_fd = -1;
+    FILE *temp = NULL;
+    const char *input = "This line is definitely longer than the buffer size provided\nNext line\n";
+    EXPECT_TRUE(redirect_stdin_from_string(input, &saved_fd, &temp) == 0);
+
+    char buffer[32];
+    int status = safe_input(buffer, sizeof(buffer), "Prompt: ");
+    EXPECT_TRUE(status == INPUT_TOO_LONG);
+    EXPECT_STREQ("", buffer);
+
+    status = safe_input(buffer, sizeof(buffer), "Prompt: ");
+    EXPECT_TRUE(status == INPUT_OK);
+    EXPECT_STREQ("Next line", buffer);
+
+    restore_stdin(saved_fd, temp);
+}
+
 static void test_is_non_empty(void)
 {
     EXPECT_TRUE(is_non_empty("Hello"));
@@ -410,6 +429,7 @@ int main(void)
     test_trim_whitespace();
     test_sanitize_input();
     test_safe_input_eof_without_newline();
+    test_safe_input_overflow_flushes();
     test_is_non_empty();
     test_contains_disallowed_csv_chars();
     test_is_valid_machine_name();

--- a/tests/test_validation.c
+++ b/tests/test_validation.c
@@ -123,6 +123,21 @@ static void test_sanitize_input(void)
     EXPECT_STREQ("Another Value", str2);
 }
 
+static void test_safe_input_eof_without_newline(void)
+{
+    int saved_fd = -1;
+    FILE *temp = NULL;
+    EXPECT_TRUE(redirect_stdin_from_string("EOF without newline", &saved_fd, &temp) == 0);
+
+    char buffer[64];
+    int status = safe_input(buffer, sizeof(buffer), "Prompt: ");
+
+    restore_stdin(saved_fd, temp);
+
+    EXPECT_TRUE(status == INPUT_OK);
+    EXPECT_STREQ("EOF without newline", buffer);
+}
+
 static void test_is_non_empty(void)
 {
     EXPECT_TRUE(is_non_empty("Hello"));
@@ -394,6 +409,7 @@ int main(void)
 {
     test_trim_whitespace();
     test_sanitize_input();
+    test_safe_input_eof_without_newline();
     test_is_non_empty();
     test_contains_disallowed_csv_chars();
     test_is_valid_machine_name();


### PR DESCRIPTION
## Summary
- ensure `safe_input` only treats newline-free reads as overflow when `stdin` still has pending data and flush the remainder before returning an error
- stop `sanitize_input` from flushing `stdin` in non-overflow cases and add a regression test that covers EOF without a trailing newline

## Testing
- gcc -std=c11 -Wall -Wextra -O2 -DUNIT_TEST -I. main.c tests/test_validation.c -o tests/test_validation
- ./tests/test_validation


------
https://chatgpt.com/codex/tasks/task_e_68dd672c6998832082802dd5d33d1f0a